### PR TITLE
update to work with remote hsds service

### DIFF
--- a/src/ramanchada2/io/HSDS.py
+++ b/src/ramanchada2/io/HSDS.py
@@ -16,7 +16,7 @@ logger = logging.getLogger()
 @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
 def write_cha(filename: str,
               dataset: str,
-              x: npt.NDArray, y: npt.NDArray, meta: Dict, h5module = None):
+              x: npt.NDArray, y: npt.NDArray, meta: Dict, h5module=None):
     data = np.stack([x, y])
     try:
         _h5 = h5module or h5py
@@ -31,7 +31,7 @@ def write_cha(filename: str,
 
 
 def read_cha(filename: str,
-             dataset: str, h5module = None
+             dataset: str, h5module=None
              ) -> Tuple[npt.NDArray, npt.NDArray, Dict]:
     _h5 = h5module or h5py
     with _h5.File(filename, mode= 'r') as h5:

--- a/src/ramanchada2/io/HSDS.py
+++ b/src/ramanchada2/io/HSDS.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple, Dict
 
-import h5py, h5pyd
+import h5py
 import logging
 import numpy as np
 import numpy.typing as npt
@@ -20,7 +20,7 @@ def write_cha(filename: str,
     data = np.stack([x, y])
     try:
         _h5 = h5module or h5py
-        with _h5.File(filename, mode= 'a') as h5:
+        with _h5.File(filename, mode='a') as h5:
             if h5.get(dataset) is None:
                 ds = h5.create_dataset(dataset, data=data)
                 ds.attrs.update(meta)
@@ -34,7 +34,7 @@ def read_cha(filename: str,
              dataset: str, h5module=None
              ) -> Tuple[npt.NDArray, npt.NDArray, Dict]:
     _h5 = h5module or h5py
-    with _h5.File(filename, mode= 'r') as h5:
+    with _h5.File(filename, mode='r') as h5:
         data = h5.get(dataset)
         if data is None:
             raise ChadaReadNotFoundError(f'dataset `{dataset}` not found in file `{filename}`')

--- a/src/ramanchada2/io/HSDS.py
+++ b/src/ramanchada2/io/HSDS.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple, Dict
 
-import h5py
+import h5py, h5pyd
 import logging
 import numpy as np
 import numpy.typing as npt
@@ -16,10 +16,11 @@ logger = logging.getLogger()
 @pydantic.validate_arguments(config=dict(arbitrary_types_allowed=True))
 def write_cha(filename: str,
               dataset: str,
-              x: npt.NDArray, y: npt.NDArray, meta: Dict):
+              x: npt.NDArray, y: npt.NDArray, meta: Dict, h5module = None):
     data = np.stack([x, y])
     try:
-        with h5py.File(filename, 'a') as h5:
+        _h5 = h5module or h5py
+        with _h5.File(filename, mode= 'a') as h5:
             if h5.get(dataset) is None:
                 ds = h5.create_dataset(dataset, data=data)
                 ds.attrs.update(meta)
@@ -30,9 +31,10 @@ def write_cha(filename: str,
 
 
 def read_cha(filename: str,
-             dataset: str
+             dataset: str, h5module = None
              ) -> Tuple[npt.NDArray, npt.NDArray, Dict]:
-    with h5py.File(filename, 'r') as h5:
+    _h5 = h5module or h5py
+    with _h5.File(filename, mode= 'r') as h5:
         data = h5.get(dataset)
         if data is None:
             raise ChadaReadNotFoundError(f'dataset `{dataset}` not found in file `{filename}`')

--- a/src/ramanchada2/spectrum/creators/from_chada.py
+++ b/src/ramanchada2/spectrum/creators/from_chada.py
@@ -6,7 +6,6 @@ from ramanchada2.io.HSDS import read_cha
 from ramanchada2.misc.spectrum_deco import add_spectrum_constructor
 from ..spectrum import Spectrum
 
-import h5py
 
 @add_spectrum_constructor(set_applied_processing=False)
 @pydantic.validate_arguments

--- a/src/ramanchada2/spectrum/creators/from_chada.py
+++ b/src/ramanchada2/spectrum/creators/from_chada.py
@@ -6,9 +6,10 @@ from ramanchada2.io.HSDS import read_cha
 from ramanchada2.misc.spectrum_deco import add_spectrum_constructor
 from ..spectrum import Spectrum
 
+import h5py
 
 @add_spectrum_constructor(set_applied_processing=False)
 @pydantic.validate_arguments
-def from_chada(filename: str, dataset: str = '/raw'):
-    x, y, meta = read_cha(filename, dataset)
+def from_chada(filename: str, dataset: str = '/raw', h5module=None):
+    x, y, meta = read_cha(filename, dataset, h5module=h5module)
     return Spectrum(x=x, y=y, metadata=meta)  # type: ignore


### PR DESCRIPTION
- remote h5rest support , pass h5pyd module instead of h5py. Or any module implementing h5pyd client Folder and File functionalities (e.g. https://github.com/h2020charisma/charisma-api/blob/refactoring/app/services/service_h5.py )
- test not added, have to decide on credentials/approach  for HSDS testing
```
from ramanchada2 import spectrum

import h5pyd 
spe = Spectrum.from_chada("/SANDBOX/example/example/example/hsds_path.cha",h5module=h5pyd)
````