### PR TITLE
Fix for oppositely sorted x-axis

### DIFF
--- a/src/ramanchada2/spectrum/creators/from_local_file.py
+++ b/src/ramanchada2/spectrum/creators/from_local_file.py
@@ -37,10 +37,12 @@ def from_local_file(
     elif filetype in {'txt', 'txtr', 'prn', 'rruf'}:
         with open(in_file_name) as fp:
             x, y, meta = read_txt(fp)
-            return Spectrum(x=x, y=y, metadata=meta)  # type: ignore
+            spe = Spectrum(x=x, y=y, metadata=meta)  # type: ignore
     elif filetype in {'csv'}:
         with open(in_file_name) as fp:
             x, y, meta = read_csv(fp)
-            return Spectrum(x=x, y=y, metadata=meta)  # type: ignore
+            spe = Spectrum(x=x, y=y, metadata=meta)  # type: ignore
     else:
         raise ValueError(f'filetype {filetype} not supported')
+    spe._sort_x()
+    return spe

--- a/src/ramanchada2/spectrum/spectrum.py
+++ b/src/ramanchada2/spectrum/spectrum.py
@@ -102,7 +102,7 @@ class Spectrum(Plottable):
             **kwargs
         )
 
-    def sort_x(self):
+    def _sort_x(self):
         idx = np.argsort(self.x)
         self.x = self.x[idx]
         self.y = self.y[idx]


### PR DESCRIPTION
In the software it is assumed that values in the x-axis are sorted in ascending order. In some data files the x-axis is sorted in descending order which causes a problem. So the spectra are always sorted.