### PR TITLE
h5pyd not a direct dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
         "numpy",
         "matplotlib",
         "h5py",
-        "h5pyd",
         "scipy>=1.8.0",
         "uncertainties",
         "pydantic",

--- a/src/ramanchada2/io/HSDS.py
+++ b/src/ramanchada2/io/HSDS.py
@@ -3,7 +3,6 @@
 from typing import Tuple, Dict
 
 import h5py
-import h5pyd
 import logging
 import numpy as np
 import numpy.typing as npt
@@ -46,14 +45,14 @@ def read_cha(filename: str,
 
 def filter_dataset(topdomain, domain, process_file, sample=None, wavelength=None, instrument=None,
                    provider=None, investigation=None, kwargs={}, h5module=None):
-    _h5 = h5module or h5pyd
+    _h5 = h5module or h5py
     with _h5.File(domain) as dataset:
         if (sample is not None) and (dataset["annotation_sample"].attrs["sample"] == sample):
             process_file(topdomain, domain, **kwargs)
 
 
 def visit_domain(topdomain="/", process_dataset=None, kwargs={}, h5module=None):
-    _h5 = h5module or h5pyd
+    _h5 = h5module or h5py
     if topdomain.endswith("/"):
         with _h5.Folder(topdomain) as domain:
             domain._getSubdomains()


### PR DESCRIPTION
Due to this problem https://stackoverflow.com/questions/74189694/cannot-import-name-external-account-authorized-user-from-google-auth and due to the fact that ramanchada2 does not actually use any features from h5pyd, i propose to remove it from the dependency list.

There only 2 functions in /io/HSDS.py that use h5pyd as a default parameter, so i changed the default to be h5py (without 'd').

The option to provide argument `h5module=h5pyd` remains untouched.