### PR TITLE
Solves #64 - a bug in `rc2.spectrum.from_delta_lines`

### DIFF
--- a/src/ramanchada2/spectrum/creators/from_delta_lines.py
+++ b/src/ramanchada2/spectrum/creators/from_delta_lines.py
@@ -37,8 +37,11 @@ def from_delta_lines(
     if xcal is None:
         dk = list(deltas.keys())
         dkmin, dkmax = np.min(dk), np.max(dk)
-        dkmin -= (dkmax-dkmin) * .1
-        dkmax += (dkmax-dkmin) * .1
+        if dkmin == dkmax:
+            dkmin, dkmax = dkmin*.8, dkmax*1.2
+        else:
+            dkmin -= (dkmax-dkmin) * .1
+            dkmax += (dkmax-dkmin) * .1
         x = np.linspace(dkmin, dkmax, nbins, endpoint=False, dtype=float)
     else:
         x = np.linspace(xcal(0), xcal(nbins), nbins, endpoint=False)


### PR DESCRIPTION
If only `deltas` and `nbins` are provided, the algorithm calculates boundaries 10% wider than provided lines. This way there are some zeros before the first delta line and some after the last one. Otherwise a confolution will lead to artefacts on the opposite side of the spectrum.

There was a problem when only a single line is provided -- all x-axis values were equal to the delta line. The problem is fixed. Now when a single lien is provided the boundaries are by 20% wider on both sides.