### PR TITLE
ops: conda: opusFC requires python<=3.10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,15 +1,17 @@
 name: ramanchada2
 channels:
   - conda-forge
-  - default
+  - nodefaults
 dependencies:
+  - python<=3.10
+  - mamba
+  - pip
   - h5py
   - jupyter
   - lmfit
   - matplotlib
   - numpy
   - pandas
-  - pip
   - pydantic
   - scipy
   - uncertainties


### PR DESCRIPTION
Creating a Conda env fails with Python>3.10
```
ERROR: Could not find a version that satisfies the requirement opusFC (from ramanchada2) (from versions: none)
ERROR: No matching distribution found for opusFC
```