### PR TITLE
Pin SciPy to <1.12 for now because of pyhht

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ INSTALL_REQUIRES = [
         "pyhht",
         "renishawWiRE",  # rc1-parser
         "scikit-learn",
-        "scipy>=1.8.0",
+        "scipy>=1.8.0,<1.12",
         "spc-io~=0.0.2",  # rc1-parser
         "statsmodels",
         "uncertainties",


### PR DESCRIPTION
pyhht imports `angle` from SciPy, which since 1.12.0 should be imported from NumPy. A fix was committed to pyhht, but a package with the fix is yet to be released. Pinning a Git release with an existing PyPI package can be tricky so this seems the best solution at this moment.

Ref: https://github.com/jaidevd/pyhht/commit/4ac9aaf98c56387729da26e078ce68221ba5b135