### PR TITLE
ops: pin deps versions and improve quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Harmonising Raman spectroscopy: meant to fill the gap between the theoretical Ra
 - ⚗️ [Examples](https://github.com/h2020charisma/ramanchada2/tree/main/examples)
 
 
+## Mini quick start with Conda
+
+**NOTICE**: See the next section for more details and examples with venv-managed virtual environments.
+
+[Install Miniforge](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download) if you don't have Conda already installed, then run the following:
+```
+git clone https://github.com/h2020charisma/ramanchada2.git
+cd ramanchada2
+conda env create
+conda activate ramanchada2
+jupyter notebook
+```
+
 ## Quick start
 
 Clone the repo using https
@@ -64,19 +77,5 @@ jupyter-lab
 
 A web browser with jupyter should start automaticaly.
 
-
-## Quick start with Conda
-
-[Install Miniconda](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) and, optionally, Mamba:
-```
-conda install mamba -n base -c conda-forge
-```
-
-Run the following. If you haven't installed Mamba, replace `mamba` with `conda`.
-```
-mamba env update -f environment.yml
-conda activate ramanchada2
-jupyter notebook
-```
 ---
 🇪🇺 This project has received funding from the European Union’s Horizon 2020 research and innovation program under [grant agreement No. 952921](https://cordis.europa.eu/project/id/952921).

--- a/environment.yml
+++ b/environment.yml
@@ -3,18 +3,9 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python==3.11
-  - h5py
-  - jupyter
-  - lmfit
-  - mamba
-  - matplotlib
-  - numpy
-  - pandas
+  - python==3.11.*
   - pip
-  - pydantic==1.*
-  - scipy
-  - uncertainties
   - pip:
+    - jupyter
     - -e .
 

--- a/setup.py
+++ b/setup.py
@@ -38,20 +38,20 @@ PACKAGE_DATA = {'': ['auxiliary/**/*.txt']}
 DATA_FILES = []
 
 INSTALL_REQUIRES = [
-        "brukeropusreader",  # rc1-parser
-        "h5py",
-        "lmfit",
-        "matplotlib",
-        "numpy",
-        "pandas",
+        "brukeropusreader==1.*",  # rc1-parser
+        "h5py==3.*",
+        "lmfit==1.*",
+        "matplotlib==3.*",
+        "numpy==1.*",
+        "pandas==2.*",
         "pydantic==1.*",
-        "emd",
-        "renishawWiRE",  # rc1-parser
-        "scikit-learn",
-        "scipy>=1.8.0",
-        "spc-io~=0.0.2",  # rc1-parser
-        "statsmodels",
-        "uncertainties",
+        "emd==0.7.*",
+        "renishawWiRE==0.1.*",  # rc1-parser
+        "scikit-learn==1.*",
+        "scipy>=1.8.0,<2.0",
+        "spc-io==0.1.*",  # rc1-parser
+        "statsmodels==0.14.*",
+        "uncertainties==3.*",
 ]
 
 CLASSIFIERS = [


### PR DESCRIPTION
- Since the transition to Poetry is put on hold for now, let's pin the dependency versions in `setup.py` as well to avoid problems like we faced with Pydantic 2.* and Numpy 2.* in the future. The requirements can probably be more relaxed and allow even lower versions than the ones introduced (which are the current minor version or patch version for prerelease packages), but this would require extensive testing.
- Update and simplify `environment.yml` for easier and less error-prone setup with Conda.
- Improvements for the quick start instructions (though not as comprehensive as in the `poetrify` branch).