### PR TITLE
tox: add quick testing environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,14 @@ change_dir = {toxinidir}
 pass_env = COVERAGE_FILE
 commands = pytest --cov {posargs}
 
+[testenv:quick]
+commands =
+    pytest \
+        --deselect tests/peak/pearson4_test.py::test_generate_and_fit_noise \
+        --deselect tests/peak/pearson4_test.py::test_generate_and_fit_noise_shift \
+        --deselect tests/protocols/test_twinning.py::test_twinning \
+        --ignore tests/protocols/test_calibrationmodel.py
+
 [testenv:clean]
 deps = coverage
 skip_install = true


### PR DESCRIPTION
This excludes all tests with duration >1s and doesn't do coverage analysis. To be used locally as `tox -e quick`.