### PR TITLE
feat: mypy 1.16

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = coverage erase
 
 [testenv:mypy]
 base_python = python3.13
-deps = mypy==1.15.*
+deps = mypy==1.16.*
 commands = mypy src tests
 
 [testenv:black]


### PR DESCRIPTION
As discussed, we have some problems with mypy 1.16, while 1.15 works fine. The changes in 1.16 are documented [here](https://mypy.readthedocs.io/en/stable/changelog.html#mypy-1-16). The error messages are [here](https://github.com/h2020charisma/ramanchada2/actions/runs/16216093355/job/45785765110#step:5:376). No need to hurry with this, but would be helpful to have it fixed nonetheless.

```
  mypy: commands[0]> mypy src tests
  src/ramanchada2/io/experimental/read_txt.py:50: error: Value of type "tuple[str, ...] | None" is not indexable  [index]
  src/ramanchada2/io/experimental/read_txt.py:51: error: Value of type "tuple[str, ...] | None" is not indexable  [index]
  src/ramanchada2/spectrum/spectrum.py:38: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[floating[Any]]]", variable has type "ndarray[tuple[int, ...], dtype[float64]]")  [assignment]
  src/ramanchada2/spectrum/spectrum.py:138: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "None")  [assignment]
  src/ramanchada2/spectrum/spectrum.py:139: error: "None" has no attribute "flags"  [attr-defined]
  src/ramanchada2/spectrum/spectrum.py:157: error: Incompatible types in assignment (expression has type "ndarray[tuple[int, ...], dtype[float64]]", variable has type "None")  [assignment]
  src/ramanchada2/spectrum/spectrum.py:158: error: "None" has no attribute "flags"  [attr-defined]
  src/ramanchada2/spectrum/calibration/scale_xaxis.py:56: error: Incompatible types in assignment (expression has type "float", variable has type "ndarray[tuple[int, ...], dtype[float64]]")  [assignment]
  Found 8 errors in 3 files (checked 160 source files)
```